### PR TITLE
feat: Add refresh button to widget

### DIFF
--- a/app/src/main/java/cc/ddsakura/modernapp001/HelloWorldWidget.kt
+++ b/app/src/main/java/cc/ddsakura/modernapp001/HelloWorldWidget.kt
@@ -10,6 +10,7 @@ import androidx.glance.GlanceTheme
 import androidx.glance.ImageProvider
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.components.CircleIconButton
 import androidx.glance.appwidget.components.Scaffold
 import androidx.glance.appwidget.components.TitleBar
 import androidx.glance.appwidget.provideContent
@@ -40,7 +41,17 @@ class HelloWorldWidget : GlanceAppWidget() {
                 TitleBar(
                     textColor = GlanceTheme.colors.onSurface,
                     startIcon = ImageProvider(R.drawable.ic_launcher_foreground),
-                    title = "Hello World Widget",
+                    title = "Hello!",
+                    actions = {
+                        CircleIconButton(
+                            imageProvider = ImageProvider(R.drawable.refresh_icon),
+                            contentDescription = "Refresh",
+                            contentColor = GlanceTheme.colors.secondary,
+                            backgroundColor = null, // transparent
+                            onClick = { /* do something */
+                            }
+                        )
+                    }
                 )
             },
             backgroundColor = GlanceTheme.colors.widgetBackground,

--- a/app/src/main/res/drawable/refresh_icon.xml
+++ b/app/src/main/res/drawable/refresh_icon.xml
@@ -1,0 +1,3 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+    <path android:fillColor="@android:color/white" android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>


### PR DESCRIPTION
Added a refresh button to the Hello World widget, allowing users to manually trigger an update.

The refresh button is
 displayed as a circular icon in the top-right corner of the widget. Clicking the button will execute a placeholder action that can be customized to perform the desired refresh functionality.