### PR TITLE
chore: Update dependencies and compileSdk

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "cc.ddsakura.modernapp001"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "cc.ddsakura.modernapp001"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 activity-compose = "1.9.3"
-agp = "8.7.1"
+agp = "8.7.2"
 androidx-junit = "1.2.1"
 appcompat = "1.7.0"
-constraintlayout = "2.1.4"
-core-ktx = "1.13.1"
+constraintlayout = "2.2.0"
+core-ktx = "1.15.0"
 desugar_jdk_libs = "2.1.2"
 espresso-core = "3.6.1"
-fragment-ktx = "1.8.4"
+fragment-ktx = "1.8.5"
 glance = "1.1.1"
 junit = "4.13.2"
 kotlin = "2.0.0"
@@ -16,7 +16,7 @@ material = "1.12.0"
 navigation-compose = "2.8.3"
 retrofit = "2.9.0"
 webkit = "1.12.1"
-composeBom = "2024.10.00"
+composeBom = "2024.10.01"
 
 [libraries]
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }


### PR DESCRIPTION
This commit updates the following dependencies:

- Android Gradle Plugin (AGP) to 8.7.2
- Compose BOM to 2024.10.01
- ConstraintLayout to 2.2.0
- Core KTX to 1.15.0
- Fragment KTX to 1.8.5

It also updates the compileSdk to 35.