### PR TITLE
Restore OIDC permission for Claude action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,6 +33,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
       actions: read
 
     steps:


### PR DESCRIPTION
## Summary

- Restore `id-token: write` for the Claude Code workflow.
- The first issue-triggered test failed because `anthropics/claude-code-action@v1` requested a GitHub OIDC token while setting up its GitHub App authentication path.
- Keep the rest of the workflow unchanged.

## Validation

- `actionlint .github/workflows/claude.yml`
- `git diff --check`
- YAML parse check

## Context

Failed run: https://github.com/ddsakura/modernapp001/actions/runs/28985016506/job/86012001896
